### PR TITLE
Utilizar todos los argumentos pasados

### DIFF
--- a/valgreen
+++ b/valgreen
@@ -9,7 +9,7 @@ VFLAGS = ["--leak-check=full", "--track-origins=yes", "--show-reachable=yes"]
 
 
 def call_valgrind(exec, flags=VFLAGS):
-    valgrind = subprocess.Popen(["valgrind", *flags].extend(exec),
+    valgrind = subprocess.Popen(["valgrind", *flags, *exec],
                                 stdin=subprocess.DEVNULL, 
                                 stdout=subprocess.PIPE, 
                                 stderr=subprocess.STDOUT)

--- a/valgreen
+++ b/valgreen
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-import argparse
 import subprocess
 import re
+import sys
 from Beautifier.Beautifier import Beautifier
 
 VFLAGS = ["--leak-check=full", "--track-origins=yes", "--show-reachable=yes"]
 
 
 def call_valgrind(exec, flags=VFLAGS):
-    valgrind = subprocess.Popen(["valgrind", *flags, exec],
+    valgrind = subprocess.Popen(["valgrind", *flags].extend(exec),
                                 stdin=subprocess.DEVNULL, 
                                 stdout=subprocess.PIPE, 
                                 stderr=subprocess.STDOUT)
@@ -17,10 +17,7 @@ def call_valgrind(exec, flags=VFLAGS):
     return out.decode("utf-8")
 
 def valgreen():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('exec', help='Executable file passed to Valgrind', type=str)
-    args = parser.parse_args()
-    output = call_valgrind(args.exec)
+    output = call_valgrind(sys.argv[1:])
     beautifier = Beautifier()
     colored_output = beautifier.process(output)
     print(colored_output)


### PR DESCRIPTION
Creo que se está haciendo un overkill usando parse args siendo que solo se va a recibir un tipo de parámetro (que además no debería tener nombre). Todos los parámetros recibidos son parte del programa al que se le aplica `valgreen`. Particularmente esto genera que si paso más de un parámetro, pinche valgreen. Seguramente se puede configurar para tener "resto opcionales" pero dudo que valga la pena.

(fixes #1)