### PR TITLE
Redirigir stdin y stdout al proceso

### DIFF
--- a/valgreen
+++ b/valgreen
@@ -10,10 +10,10 @@ VFLAGS = ["--leak-check=full", "--track-origins=yes", "--show-reachable=yes"]
 
 def call_valgrind(exec, flags=VFLAGS):
     valgrind = subprocess.Popen(["valgrind", *flags, *exec],
-                                stdin=subprocess.DEVNULL, 
-                                stdout=subprocess.PIPE, 
-                                stderr=subprocess.STDOUT)
-    out, _ = valgrind.communicate()
+                                stdin=sys.stdin,
+                                stdout=sys.stdout,
+                                stderr=subprocess.PIPE)
+    _, out = valgrind.communicate()
     return out.decode("utf-8")
 
 def valgreen():


### PR DESCRIPTION
No se puede interactuar con el proceso desde la terminal ya que Valgreen pone `stdin` a `DEVNULL` y captura todo el `stdout + stderr` para mostrar la salida.

Este cambio redirige `stdin` y `stdout` directamente al proceso permitiendo interactuar desde la terminal y utiliza sólo `stderr` para parsear la salida del Valgrind.